### PR TITLE
Added option to toggle model prefetch in config.

### DIFF
--- a/InteractiveVis/config.py
+++ b/InteractiveVis/config.py
@@ -17,6 +17,7 @@ model_folder = 'newmodel' # folder containing our trained models
 stored_models = sorted(glob.glob(os.path.join(model_folder, 'newmodel_wb_cv[1-9].hdf5'))) + sorted(glob.glob(os.path.join('newmodel', 'newmodel_wb_cv[1-2][0-9].hdf5'))) # get list of available models, global sorting not possible because of different number of digits
 #stored_models = sorted(glob.glob('newmodel/newmodel_wb_cv*.hdf5')) #get all models in subfolder, sorting still messed up
 selected_model = os.path.join(model_folder, 'newmodel_wb_cv8.hdf5') # model file name to load (default cv8 like before)
+do_model_prefetch = True
 
 #define path/name to pickle file containing covariates
 covariates_file = 'covariates.pkl'

--- a/InteractiveVis/main.py
+++ b/InteractiveVis/main.py
@@ -125,13 +125,19 @@ def select_subject_callback(attr, old, new):
     
 
 
+def select_model_worker():
+    if debug: print("Called select_model_worker().")
+    # Might take a long time if model is not cached yet.
+    m.set_model(v.model_select.value)
+    print("Finished selecting new model.")
+    v.curdoc().add_next_tick_callback(select_subject_worker)
+
 def select_model_callback(attr, old, new):
     v.disable_widgets()
 
     if debug: print("Called select_model_callback().")
-    m.set_model(v.model_select.value)
-    v.curdoc().add_next_tick_callback(select_subject_worker)
-    print("Finished selecting new model.")
+    v.curdoc().add_next_tick_callback(select_model_worker)
+
     
 
 


### PR DESCRIPTION
If the option 'do_model_prefetch' is disabled, models selected by the user will still be cached and only loaded from disk at most once. This should resolve #4.
The 'Processing scan...' label is now also shown when switching models, because this takes a long time if prefetching is disabled and the selected model is not in the cache yet.