### PR TITLE
Missing colon

### DIFF
--- a/lang/DE.JSON
+++ b/lang/DE.JSON
@@ -1,5 +1,5 @@
 {
-	"lang": "Sparache auswählen",
+	"lang": "Sparache auswählen:",
     "subject": "Person: ",
     "model": "KI-Modell: ",
     "relv_th": "Min. Relevanz",


### PR DESCRIPTION
The German translation "Sprache auswählen" is missing a colon at the end.